### PR TITLE
Update Dockerfile to pass HOST/PORT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ ENV TAVILY_API_KEY=your-api-key-here
 
 RUN npm ci --ignore-scripts --omit-dev
 
-ENTRYPOINT ["node", "build/index.js"]
+ENTRYPOINT ["sh", "-c", "exec node build/index.js${HOST:+ --host $HOST}${PORT:+ --port $PORT}"]


### PR DESCRIPTION
## Summary
- pass HOST/PORT environment variables to the node command so HTTP/SSE work in Cloud Run

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684b01f3569c832d9c77ed5450dae926